### PR TITLE
Fix demo not executing as expected

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ flowinsight run
 python demo/local_visualize.py
 ```
 
-Open **http://localhost:8080** for live visualization.
+Open **http://localhost:8000** for live visualization.
 
 
 ## 📄 License

--- a/sdk/flow_insight/api/fastapi_api.py
+++ b/sdk/flow_insight/api/fastapi_api.py
@@ -111,7 +111,9 @@ class FastAPIInsightServer(APIInterface):
 
     async def run(self, host: str, port: int, reload: bool = False, workers: int = 1):
         """Run the HTTP server."""
-        config = uvicorn.Config(self.app, host=host, port=port, access_log=False, reload=reload, workers=workers)
+        config = uvicorn.Config(
+            self.app, host=host, port=port, access_log=False, reload=reload, workers=workers
+        )
         server = uvicorn.Server(config)
         logger.info(f"Insight FastAPI server running at http://{host}:{port}")
         # Start periodic snapshot task
@@ -584,6 +586,7 @@ def create_app():
     """Create a FastAPI application instance."""
     server = FastAPIInsightServer()
     return server.app
+
 
 def run_server(
     host: str = "localhost",

--- a/sdk/flow_insight/api/fastapi_api.py
+++ b/sdk/flow_insight/api/fastapi_api.py
@@ -584,3 +584,8 @@ def create_app():
     """Create a FastAPI application instance."""
     server = FastAPIInsightServer()
     return server.app
+
+def run_server(host: str = "localhost", port: int = 8000):
+    """Run the FastAPI Insight server."""
+    server = FastAPIInsightServer()
+    asyncio.run(server.run(host, port))

--- a/sdk/flow_insight/api/fastapi_api.py
+++ b/sdk/flow_insight/api/fastapi_api.py
@@ -109,9 +109,9 @@ class FastAPIInsightServer(APIInterface):
             except Exception as e:
                 logger.error(f"Error processing record from queue: {str(e)}")
 
-    async def run(self, host: str, port: int):
+    async def run(self, host: str, port: int, reload: bool = False, workers: int = 1):
         """Run the HTTP server."""
-        config = uvicorn.Config(self.app, host=host, port=port, access_log=False)
+        config = uvicorn.Config(self.app, host=host, port=port, access_log=False, reload=reload, workers=workers)
         server = uvicorn.Server(config)
         logger.info(f"Insight FastAPI server running at http://{host}:{port}")
         # Start periodic snapshot task
@@ -585,7 +585,12 @@ def create_app():
     server = FastAPIInsightServer()
     return server.app
 
-def run_server(host: str = "localhost", port: int = 8000):
+def run_server(
+    host: str = "localhost",
+    port: int = 8000,
+    reload: bool = False,
+    workers: int = 1,
+):
     """Run the FastAPI Insight server."""
     server = FastAPIInsightServer()
-    asyncio.run(server.run(host, port))
+    asyncio.run(server.run(host, port, reload=reload, workers=workers))

--- a/sdk/flow_insight/cli.py
+++ b/sdk/flow_insight/cli.py
@@ -43,7 +43,7 @@ def main():
             print(f"Starting Flow Insight server on {args.host}:{args.port}")
             print(f"Access the dashboard at: http://{args.host}:{args.port}")
             print("Press Ctrl+C to stop the server")
-            
+
             workers = args.workers if not args.reload else 1
             run_server(
                 host=args.host,

--- a/sdk/flow_insight/cli.py
+++ b/sdk/flow_insight/cli.py
@@ -39,11 +39,18 @@ def main():
 
     if args.command in ["run", "serve", "start"]:
         try:
-            run_server(host=args.host, port=args.port)
 
             print(f"Starting Flow Insight server on {args.host}:{args.port}")
             print(f"Access the dashboard at: http://{args.host}:{args.port}")
             print("Press Ctrl+C to stop the server")
+            
+            workers = args.workers if not args.reload else 1
+            run_server(
+                host=args.host,
+                port=args.port,
+                reload=args.reload,
+                workers=workers,
+            )
 
         except ImportError:
             print("Error: uvicorn is required to run the server.")

--- a/sdk/flow_insight/cli.py
+++ b/sdk/flow_insight/cli.py
@@ -8,7 +8,7 @@ import argparse
 import os
 import sys
 
-from .api.fastapi_api import create_app
+from .api.fastapi_api import run_server
 
 
 def main():
@@ -39,21 +39,11 @@ def main():
 
     if args.command in ["run", "serve", "start"]:
         try:
-            import uvicorn
-
-            app = create_app()
+            run_server(host=args.host, port=args.port)
 
             print(f"Starting Flow Insight server on {args.host}:{args.port}")
             print(f"Access the dashboard at: http://{args.host}:{args.port}")
             print("Press Ctrl+C to stop the server")
-
-            uvicorn.run(
-                app,
-                host=args.host,
-                port=args.port,
-                reload=args.reload,
-                workers=args.workers if not args.reload else 1,
-            )
 
         except ImportError:
             print("Error: uvicorn is required to run the server.")

--- a/sdk/flow_insight/engine.py
+++ b/sdk/flow_insight/engine.py
@@ -22,7 +22,6 @@ from flow_insight.storage.snapshot.model import (
     DebuggerInfo,
     DebuggerInfoEvent,
     DebugSession,
-    FlameTree,
     FlameTreeNode,
     MetaInfoRegisterEvent,
     Method,

--- a/sdk/flow_insight/engine.py
+++ b/sdk/flow_insight/engine.py
@@ -673,10 +673,8 @@ class InsightEngine:
             snapshot = self._snapshots["latest"]
         flame_tree = await snapshot.get_flame_tree(flow_id)
         if flame_tree is None:
-            return FlameTree(
-                root=FlameTreeNode(
-                    span_id="_main", id="_main", start_time=0, end_time=-1, children=[]
-                )
+            return FlameTreeNode(
+                span_id="_main", id="_main", start_time=0, end_time=-1, children=[]
             )
         root_node = flame_tree
 

--- a/sdk/flow_insight/visualize/decorator.py
+++ b/sdk/flow_insight/visualize/decorator.py
@@ -2,6 +2,7 @@
 
 import inspect
 import sys
+import threading
 import time
 import uuid
 from functools import wraps
@@ -56,8 +57,6 @@ class CallContext:
 
 
 # Thread-local storage for call context
-import threading
-
 _call_context = threading.local()
 
 
@@ -161,7 +160,7 @@ def create_instrumented_method(original_method, service_name: str, method_name: 
 
             return result
 
-        except Exception as e:
+        except Exception:
             # Pop the current span from context
             context.pop_span()
 


### PR DESCRIPTION
## Summary by Sourcery

Update the Flow Insight CLI to start the FastAPI server via a dedicated server runner and align documentation with the default server port.

Bug Fixes:
- Ensure the Flow Insight server starts correctly from the CLI by delegating to the FastAPIInsightServer run method instead of manually invoking uvicorn.

Enhancements:
- Introduce a run_server helper in the FastAPI API module to encapsulate starting the FastAPIInsightServer with host and port parameters.

Documentation:
- Correct the README demo instructions to point to the default server URL at http://localhost:8000 instead of port 8080.